### PR TITLE
Trying to fix #179

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,12 @@
+# coding: utf-8
 class UserMailer < ApplicationMailer
   def send_verify_code(email, code)
     @code = code
     mail(to: email, subject: '[极客公园] Hi, 极客 您的邮箱校验码')
+  rescue Net::ReadTimeout, Net::OpenTimeout => e
+    Rails.logger.error 'Send verification code timeout'
+    Rails.logger.error e.message
+    Rails.logger.error caller
+    retry
   end
 end


### PR DESCRIPTION
According to https://stackoverflow.com/questions/16040158/rails-mailer-netopentimeout-execution-expired-exception-on-production-serve, this issue might be caused by wrongly configured IPv6 routing. So I have disabled IPv6 on the production server, hopefully that will fix the problem. 

I also offered this patch as a backup solution to retry when the error occurs, for if it's just caused by temporary network problem.
